### PR TITLE
Fixed comment that said we're showing the Google homepage from bing.com

### DIFF
--- a/10_Requests/app.js
+++ b/10_Requests/app.js
@@ -3,7 +3,7 @@ var fs = require("fs");
 //Example 1 : Let's grab a page 
 request("http://www.bing.com", function(error, response, body) {
   if (!error && response.statusCode == 200) {
-    console.log(body) // Show the HTML for the Google homepage.
+    console.log(body) // Show the HTML for the Bing homepage.
   }
 
 });


### PR DESCRIPTION
The comment says "Show the HTML for the Google homepage" but the URL right above it is bing.com, so I think the author meant to say Bing homepage. I'm about to give a presentation to college students using this code so I just wanted to eliminate any unnecessary distractions :D .